### PR TITLE
Refactor/Usecase model keys

### DIFF
--- a/previsionio/usecase.py
+++ b/previsionio/usecase.py
@@ -42,7 +42,8 @@ class BaseUsecase(ApiResource):
         self.training_config = TrainingConfig(profile=usecase_params.get('profile'),
                                               fe_selected_list=usecase_params.get(
                                                   'featuresEngineeringSelectedList'),
-                                              models=usecase_params.get('models'),
+                                              normal_models=usecase_params.get('normalModels'),
+                                              lite_models=usecase_params.get('liteModels'),
                                               simple_models=usecase_params.get('simpleModels'))
 
         self._id = usecase_info.get('usecaseId')
@@ -369,13 +370,22 @@ class BaseUsecase(ApiResource):
         return self._status['usecaseParameters'].get('featuresEngineeringSelectedList')
 
     @property
-    def models_list(self):
-        """ Get the list of selected models in the usecase.
+    def normal_models_list(self):
+        """ Get the list of selected normal models in the usecase.
 
         Returns:
-            list(str): Names of the models selected for the usecase
+            list(str): Names of the normal models selected for the usecase
         """
-        return self._status['usecaseParameters'].get('models')
+        return self._status['usecaseParameters'].get('normalModels')
+
+    @property
+    def lite_models_list(self):
+        """ Get the list of selected lite models in the usecase.
+
+        Returns:
+            list(str): Names of the lite models selected for the usecase
+        """
+        return self._status['usecaseParameters'].get('liteModels')
 
     @property
     def simple_models_list(self):

--- a/previsionio/usecase_config.py
+++ b/previsionio/usecase_config.py
@@ -296,25 +296,29 @@ class ColumnConfig(UsecaseConfig):
 
 
 base_config = TrainingConfig(profile=Profile.Normal,
-                             models=Model.Full,
+                             normal_models=Model.Full,
+                             lite_models=LiteModel.Full,
                              simple_models=SimpleModel.Full,
                              features=Feature.Full.drop(Feature.PCA, Feature.KMeans),
                              with_blend=True)
 
 quick_config = TrainingConfig(profile=Profile.Quick,
-                              models=Model.Full.drop(Model.NeuralNet),
+                              normal_models=Model.Full.drop(Model.NeuralNet),
+                              lite_models=LiteModel.Full.drop(LiteModel.NeuralNet),
                               simple_models=SimpleModel.Full.drop(SimpleModel.LinReg),
                               features=Feature.Full.drop(Feature.PCA, Feature.KMeans),
                               with_blend=False)
 
 ultra_config = TrainingConfig(profile=Profile.Quick,
                               features=Feature.Full.drop(Feature.PCA, Feature.KMeans),
-                              models=[Model.XGBoost],
+                              normal_models=[Model.XGBoost],
+                              lite_models=[LiteModel.XGBoost],
                               simple_models=[SimpleModel.LinReg],
                               with_blend=False)
 
 nano_config = TrainingConfig(profile=Profile.Quick,
-                             models=[Model.LinReg],
+                             normal_models=[Model.LinReg],
+                             lite_models=[LiteModel.LinReg],
                              simple_models=[],
                              features=[],
                              with_blend=False)

--- a/previsionio/usecase_config.py
+++ b/previsionio/usecase_config.py
@@ -25,7 +25,32 @@ class TypeProblem(object):
 
 
 class Model(object):
-    """ Types of models that can be trained with Prevision.io.
+    """ Types of normal models that can be trained with Prevision.io.
+    The ``Full`` member is a shortcut to get all available models at once.
+    To just drop a single model from a list of models, use:
+
+    .. code-block:: python
+
+        LiteModel.drop(LiteModel.xxx)
+    """
+    LightGBM = 'LGB'
+    """LightGBM"""
+    XGBoost = 'XGB'
+    """XGBoost"""
+    NeuralNet = 'NN'
+    """NeuralNet"""
+    ExtraTrees = 'ET'
+    """ExtraTrees"""
+    LinReg = 'LR'
+    """Linear Regression"""
+    RandomForest = 'RF'
+    """Random Forest"""
+    Full = ParamList(['LGB', 'XGB', 'NN', 'ET', 'LR', 'RF'])
+    """Evaluate all models"""
+
+
+class LiteModel(object):
+    """ Types of lite models that can be trained with Prevision.io.
     The ``Full`` member is a shortcut to get all available models at once.
     To just drop a single model from a list of models, use:
 
@@ -107,7 +132,7 @@ class Profile(object):
 
 class UsecaseConfig(object):
 
-    list_args = {'fe_selected_list', 'drop_list', 'models'}
+    list_args = {'fe_selected_list', 'drop_list', 'normal_models'}
 
     config = {}
 
@@ -171,7 +196,8 @@ class TrainingConfig(UsecaseConfig):
     """
 
     config = {
-        'models': 'models',
+        'normal_models': 'normalModels',
+        'lite_models': 'liteModels',
         'simple_models': 'simpleModels',
         'fe_selected_list': 'featuresEngineeringSelectedList',
         'profile': 'profile',
@@ -180,7 +206,8 @@ class TrainingConfig(UsecaseConfig):
 
     def __init__(self,
                  profile=Profile.Normal,
-                 models=Model.Full,
+                 normal_models=Model.Full,
+                 lite_models=LiteModel.Full,
                  simple_models=SimpleModel.Full,
                  features=Feature.Full,
                  with_blend=False,
@@ -189,7 +216,8 @@ class TrainingConfig(UsecaseConfig):
 
         Args:
             profile:
-            models:
+            normal_models:
+            lite_models:
             simple_models:
             features:
             with_blend:
@@ -201,7 +229,8 @@ class TrainingConfig(UsecaseConfig):
         else:
             self.fe_selected_list = [f for f in Feature.Full if f in features]
 
-        self.models = models
+        self.normal_models = normal_models
+        self.lite_models = lite_models
         self.simple_models = simple_models
 
         self.profile = profile

--- a/utests/test_supervised.py
+++ b/utests/test_supervised.py
@@ -11,7 +11,8 @@ TESTING_ID = get_testing_id()
 pio.config.zip_files = False
 pio.config.default_timeout = 80
 
-uc_config = pio.TrainingConfig(models=[pio.Model.LinReg],
+uc_config = pio.TrainingConfig(normal_models=[pio.Model.LinReg],
+                               lite_models=[pio.Model.LinReg],
                                simple_models=[pio.SimpleModel.DecisionTree],
                                features=[pio.Feature.Counts],
                                profile=pio.Profile.Quick)
@@ -128,7 +129,7 @@ class TestUCGeneric:
     def test_drop_models(self, setup_usecase_class):
         type_problem, uc = setup_usecase_class
         uc.update_status()
-        assert sorted(uc.models_list) == sorted(uc_config.models)
+        assert sorted(uc.normal_models_list) == sorted(uc_config.normal_models)
         assert sorted(uc.simple_models_list) == sorted(uc_config.simple_models)
 
 

--- a/utests/test_timeseries.py
+++ b/utests/test_timeseries.py
@@ -52,7 +52,8 @@ def train_model(uc_name, groups=1, time_window=pio.TimeWindow(-90, -30, 1, 15), 
     dataset = pio.Dataset.new(name=uc_name,
                               dataframe=data)
 
-    uc_config = pio.TrainingConfig(models=[pio.Model.LinReg],
+    uc_config = pio.TrainingConfig(normal_models=[pio.Model.LinReg],
+                                   lite_models=[pio.Model.LinReg],
                                    features=[pio.Feature.Counts],
                                    profile=pio.Profile.Quick)
 


### PR DESCRIPTION
Suite à un changement dans l'API du backend de Pio, on doit maintenant passer 3 clés pour les modèles lors de la création d'un usecase : `simpleModels`, `liteModels` et `normalModels`.

Pour l'instant, les listes de `liteModels` et `normalModels` restent identiques.

Avant :
`models` : modèles normaux (et lite, en duplicata)
`simpleModels` : modèles simples

Après :
`normalModels` : modèles normaux
`liteModels` : modèles lite
`simpleModels` : modèles simples