### PR TITLE
Fix/retry policy and dataframe upload

### DIFF
--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -1,6 +1,54 @@
 from __future__ import print_function
 import logging
+
+from previsionio.analyzer import cv_classif_analysis
+from previsionio.connector import Connector
+from previsionio.dataset import Dataset, DatasetImages
+from previsionio.datasource import DataSource
+from previsionio.deployed_model import DeployedModel
 from previsionio.logger import logger, event_logger
+import previsionio.metrics as metrics
+from previsionio.model import (
+    Model,
+    ClassificationModel,
+    RegressionModel,
+    MultiClassificationModel,
+    TextSimilarityModel,
+)
+from previsionio.prevision_client import client
+from previsionio.project import Project
+from previsionio.supervised import Supervised
+from previsionio.text_similarity import (
+    TextSimilarity,
+    DescriptionsColumnConfig,
+    QueriesColumnConfig,
+    ListModelsParameters,
+    ModelsParameters,
+    TextSimilarityModels,
+    ModelEmbedding,
+    Preprocessing,
+)
+from previsionio.timeseries import (
+    TimeSeries,
+    TimeWindow,
+    TimeWindowException,
+)
+from previsionio.usecase import Usecase
+from previsionio.usecase_config import (
+    AdvancedModel,
+    NormalModel,
+    SimpleModel,
+    TypeProblem,
+    Feature,
+    TrainingConfig,
+    Profile,
+    base_config,
+    quick_config,
+    ultra_config,
+    ColumnConfig,
+    YesOrNo,
+    YesOrNoOrAuto,
+)
 
 
 __version__ = '11.0.0'
@@ -45,76 +93,46 @@ class Config:
 
 config = Config()
 
-from previsionio.prevision_client import client
-from previsionio.usecase_config import \
-    AdvancedModel, \
-    NormalModel, \
-    SimpleModel, \
-    TypeProblem, \
-    Feature, \
-    TrainingConfig, \
-    Profile, \
-    base_config, \
-    quick_config, \
-    ultra_config, \
-    ColumnConfig, \
-    YesOrNo, \
-    YesOrNoOrAuto
 
-import previsionio.metrics as metrics
-
-from previsionio.connector import Connector
-from previsionio.datasource import DataSource
-from previsionio.project import Project
-from previsionio.usecase import Usecase
-from previsionio.supervised import Supervised
-from previsionio.timeseries import TimeSeries, TimeWindow, TimeWindowException
-
-from previsionio.model import Model, ClassificationModel, RegressionModel, MultiClassificationModel, TextSimilarityModel
-from previsionio.text_similarity import TextSimilarity, DescriptionsColumnConfig, \
-    QueriesColumnConfig, ListModelsParameters, ModelsParameters, TextSimilarityModels, ModelEmbedding, Preprocessing
-from previsionio.dataset import Dataset, DatasetImages
-from previsionio.analyzer import cv_classif_analysis
-from previsionio.deployed_model import DeployedModel
-
-__all__ = ['client',
-           'AdvancedModel',
-           'NormalModel',
-           'SimpleModel',
-           'TypeProblem',
-           'Feature',
-           'TrainingConfig',
-           'YesOrNo',
-           'YesOrNoOrAuto',
-           'Profile',
-           'base_config',
-           'quick_config',
-           'ultra_config',
-           'ColumnConfig',
-           'metrics',
-           'Connector',
-           'DataSource',
-           'Supervised',
-           'TimeSeries',
-           'TimeWindow',
-           'TimeWindowException',
-           'Dataset',
-           'DatasetImages',
-           'Model',
-           'RegressionModel',
-           'ClassificationModel',
-           'MultiClassificationModel',
-           'TextSimilarityModel',
-           'cv_classif_analysis',
-           'DeployedModel',
-           'TextSimilarity',
-           'DescriptionsColumnConfig',
-           'QueriesColumnConfig',
-           'ListModelsParameters',
-           'ModelsParameters',
-           'TextSimilarityModels',
-           'ModelEmbedding',
-           'Preprocessing',
-           'Project',
-           'Usecase'
-           ]
+__all__ = [
+    'client',
+    'AdvancedModel',
+    'NormalModel',
+    'SimpleModel',
+    'TypeProblem',
+    'Feature',
+    'TrainingConfig',
+    'YesOrNo',
+    'YesOrNoOrAuto',
+    'Profile',
+    'base_config',
+    'quick_config',
+    'ultra_config',
+    'ColumnConfig',
+    'metrics',
+    'Connector',
+    'DataSource',
+    'Supervised',
+    'TimeSeries',
+    'TimeWindow',
+    'TimeWindowException',
+    'Dataset',
+    'DatasetImages',
+    'Model',
+    'RegressionModel',
+    'ClassificationModel',
+    'MultiClassificationModel',
+    'TextSimilarityModel',
+    'cv_classif_analysis',
+    'DeployedModel',
+    'TextSimilarity',
+    'DescriptionsColumnConfig',
+    'QueriesColumnConfig',
+    'ListModelsParameters',
+    'ModelsParameters',
+    'TextSimilarityModels',
+    'ModelEmbedding',
+    'Preprocessing',
+    'Project',
+    'Usecase',
+]

--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -35,6 +35,7 @@ class Config:
     def __init__(self):
         self.auto_update: bool = True
         self.zip_files: bool = True
+        self.success_codes: list = list(range(200, 211)) + [226]
         self.retry_codes: list = [500, 502, 503, 504]
         self.request_retries: int = 3
         self.request_retry_time: int = 10

--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -35,6 +35,7 @@ class Config:
     def __init__(self):
         self.auto_update: bool = True
         self.zip_files: bool = True
+        self.retry_codes: list = [500, 502, 503, 504]
         self.request_retries: int = 3
         self.request_retry_time: int = 10
         self.scheduler_refresh_rate: int = 10

--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -1,54 +1,6 @@
 from __future__ import print_function
 import logging
-
-from previsionio.analyzer import cv_classif_analysis
-from previsionio.connector import Connector
-from previsionio.dataset import Dataset, DatasetImages
-from previsionio.datasource import DataSource
-from previsionio.deployed_model import DeployedModel
 from previsionio.logger import logger, event_logger
-import previsionio.metrics as metrics
-from previsionio.model import (
-    Model,
-    ClassificationModel,
-    RegressionModel,
-    MultiClassificationModel,
-    TextSimilarityModel,
-)
-from previsionio.prevision_client import client
-from previsionio.project import Project
-from previsionio.supervised import Supervised
-from previsionio.text_similarity import (
-    TextSimilarity,
-    DescriptionsColumnConfig,
-    QueriesColumnConfig,
-    ListModelsParameters,
-    ModelsParameters,
-    TextSimilarityModels,
-    ModelEmbedding,
-    Preprocessing,
-)
-from previsionio.timeseries import (
-    TimeSeries,
-    TimeWindow,
-    TimeWindowException,
-)
-from previsionio.usecase import Usecase
-from previsionio.usecase_config import (
-    AdvancedModel,
-    NormalModel,
-    SimpleModel,
-    TypeProblem,
-    Feature,
-    TrainingConfig,
-    Profile,
-    base_config,
-    quick_config,
-    ultra_config,
-    ColumnConfig,
-    YesOrNo,
-    YesOrNoOrAuto,
-)
 
 
 __version__ = '11.0.0'
@@ -93,46 +45,76 @@ class Config:
 
 config = Config()
 
+from previsionio.prevision_client import client
+from previsionio.usecase_config import \
+    AdvancedModel, \
+    NormalModel, \
+    SimpleModel, \
+    TypeProblem, \
+    Feature, \
+    TrainingConfig, \
+    Profile, \
+    base_config, \
+    quick_config, \
+    ultra_config, \
+    ColumnConfig, \
+    YesOrNo, \
+    YesOrNoOrAuto
 
-__all__ = [
-    'client',
-    'AdvancedModel',
-    'NormalModel',
-    'SimpleModel',
-    'TypeProblem',
-    'Feature',
-    'TrainingConfig',
-    'YesOrNo',
-    'YesOrNoOrAuto',
-    'Profile',
-    'base_config',
-    'quick_config',
-    'ultra_config',
-    'ColumnConfig',
-    'metrics',
-    'Connector',
-    'DataSource',
-    'Supervised',
-    'TimeSeries',
-    'TimeWindow',
-    'TimeWindowException',
-    'Dataset',
-    'DatasetImages',
-    'Model',
-    'RegressionModel',
-    'ClassificationModel',
-    'MultiClassificationModel',
-    'TextSimilarityModel',
-    'cv_classif_analysis',
-    'DeployedModel',
-    'TextSimilarity',
-    'DescriptionsColumnConfig',
-    'QueriesColumnConfig',
-    'ListModelsParameters',
-    'ModelsParameters',
-    'TextSimilarityModels',
-    'ModelEmbedding',
-    'Preprocessing',
-    'Project',
-    'Usecase',
-]
+import previsionio.metrics as metrics
+
+from previsionio.connector import Connector
+from previsionio.datasource import DataSource
+from previsionio.project import Project
+from previsionio.usecase import Usecase
+from previsionio.supervised import Supervised
+from previsionio.timeseries import TimeSeries, TimeWindow, TimeWindowException
+
+from previsionio.model import Model, ClassificationModel, RegressionModel, MultiClassificationModel, TextSimilarityModel
+from previsionio.text_similarity import TextSimilarity, DescriptionsColumnConfig, \
+    QueriesColumnConfig, ListModelsParameters, ModelsParameters, TextSimilarityModels, ModelEmbedding, Preprocessing
+from previsionio.dataset import Dataset, DatasetImages
+from previsionio.analyzer import cv_classif_analysis
+from previsionio.deployed_model import DeployedModel
+
+__all__ = ['client',
+           'AdvancedModel',
+           'NormalModel',
+           'SimpleModel',
+           'TypeProblem',
+           'Feature',
+           'TrainingConfig',
+           'YesOrNo',
+           'YesOrNoOrAuto',
+           'Profile',
+           'base_config',
+           'quick_config',
+           'ultra_config',
+           'ColumnConfig',
+           'metrics',
+           'Connector',
+           'DataSource',
+           'Supervised',
+           'TimeSeries',
+           'TimeWindow',
+           'TimeWindowException',
+           'Dataset',
+           'DatasetImages',
+           'Model',
+           'RegressionModel',
+           'ClassificationModel',
+           'MultiClassificationModel',
+           'TextSimilarityModel',
+           'cv_classif_analysis',
+           'DeployedModel',
+           'TextSimilarity',
+           'DescriptionsColumnConfig',
+           'QueriesColumnConfig',
+           'ListModelsParameters',
+           'ModelsParameters',
+           'TextSimilarityModels',
+           'ModelEmbedding',
+           'Preprocessing',
+           'Project',
+           'Usecase'
+           ]

--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -37,7 +37,7 @@ class Config:
         self.zip_files: bool = True
         self.success_codes: list = list(range(200, 211)) + [226]
         self.retry_codes: list = [500, 502, 503, 504]
-        self.request_retries: int = 3
+        self.request_retries: int = 6
         self.request_retry_time: int = 10
         self.scheduler_refresh_rate: int = 10
         self.default_timeout: float = 3600.

--- a/previsionio/__init__.py
+++ b/previsionio/__init__.py
@@ -46,20 +46,21 @@ class Config:
 config = Config()
 
 from previsionio.prevision_client import client
-from previsionio.usecase_config import \
-    AdvancedModel, \
-    NormalModel, \
-    SimpleModel, \
-    TypeProblem, \
-    Feature, \
-    TrainingConfig, \
-    Profile, \
-    base_config, \
-    quick_config, \
-    ultra_config, \
-    ColumnConfig, \
-    YesOrNo, \
-    YesOrNoOrAuto
+from previsionio.usecase_config import (
+    AdvancedModel,
+    NormalModel,
+    SimpleModel,
+    TypeProblem,
+    Feature,
+    TrainingConfig,
+    Profile,
+    base_config,
+    quick_config,
+    ultra_config,
+    ColumnConfig,
+    YesOrNo,
+    YesOrNoOrAuto,
+)
 
 import previsionio.metrics as metrics
 
@@ -68,53 +69,71 @@ from previsionio.datasource import DataSource
 from previsionio.project import Project
 from previsionio.usecase import Usecase
 from previsionio.supervised import Supervised
-from previsionio.timeseries import TimeSeries, TimeWindow, TimeWindowException
-
-from previsionio.model import Model, ClassificationModel, RegressionModel, MultiClassificationModel, TextSimilarityModel
-from previsionio.text_similarity import TextSimilarity, DescriptionsColumnConfig, \
-    QueriesColumnConfig, ListModelsParameters, ModelsParameters, TextSimilarityModels, ModelEmbedding, Preprocessing
+from previsionio.timeseries import (
+    TimeSeries,
+    TimeWindow,
+    TimeWindowException,
+)
+from previsionio.model import (
+    Model,
+    ClassificationModel,
+    RegressionModel,
+    MultiClassificationModel,
+    TextSimilarityModel,
+)
+from previsionio.text_similarity import (
+    TextSimilarity,
+    DescriptionsColumnConfig,
+    QueriesColumnConfig,
+    ListModelsParameters,
+    ModelsParameters,
+    TextSimilarityModels,
+    ModelEmbedding,
+    Preprocessing,
+)
 from previsionio.dataset import Dataset, DatasetImages
 from previsionio.analyzer import cv_classif_analysis
 from previsionio.deployed_model import DeployedModel
 
-__all__ = ['client',
-           'AdvancedModel',
-           'NormalModel',
-           'SimpleModel',
-           'TypeProblem',
-           'Feature',
-           'TrainingConfig',
-           'YesOrNo',
-           'YesOrNoOrAuto',
-           'Profile',
-           'base_config',
-           'quick_config',
-           'ultra_config',
-           'ColumnConfig',
-           'metrics',
-           'Connector',
-           'DataSource',
-           'Supervised',
-           'TimeSeries',
-           'TimeWindow',
-           'TimeWindowException',
-           'Dataset',
-           'DatasetImages',
-           'Model',
-           'RegressionModel',
-           'ClassificationModel',
-           'MultiClassificationModel',
-           'TextSimilarityModel',
-           'cv_classif_analysis',
-           'DeployedModel',
-           'TextSimilarity',
-           'DescriptionsColumnConfig',
-           'QueriesColumnConfig',
-           'ListModelsParameters',
-           'ModelsParameters',
-           'TextSimilarityModels',
-           'ModelEmbedding',
-           'Preprocessing',
-           'Project',
-           'Usecase'
-           ]
+__all__ = [
+    'client',
+    'AdvancedModel',
+    'NormalModel',
+    'SimpleModel',
+    'TypeProblem',
+    'Feature',
+    'TrainingConfig',
+    'YesOrNo',
+    'YesOrNoOrAuto',
+    'Profile',
+    'base_config',
+    'quick_config',
+    'ultra_config',
+    'ColumnConfig',
+    'metrics',
+    'Connector',
+    'DataSource',
+    'Supervised',
+    'TimeSeries',
+    'TimeWindow',
+    'TimeWindowException',
+    'Dataset',
+    'DatasetImages',
+    'Model',
+    'RegressionModel',
+    'ClassificationModel',
+    'MultiClassificationModel',
+    'TextSimilarityModel',
+    'cv_classif_analysis',
+    'DeployedModel',
+    'TextSimilarity',
+    'DescriptionsColumnConfig',
+    'QueriesColumnConfig',
+    'ListModelsParameters',
+    'ModelsParameters',
+    'TextSimilarityModels',
+    'ModelEmbedding',
+    'Preprocessing',
+    'Project',
+    'Usecase',
+]

--- a/previsionio/api_resource.py
+++ b/previsionio/api_resource.py
@@ -1,6 +1,6 @@
 from typing import Dict
 import requests
-from .utils import handle_error_response, parse_json, PrevisionException, get_all_results
+from .utils import parse_json, get_all_results
 from .prevision_client import client
 from . import logger
 from enum import Enum
@@ -61,8 +61,8 @@ class ApiResource:
         else:
             url = specific_url
         # call api, add event to eventmanager events if available and return
-        resource_status = client.request(url, method=requests.get)
-        handle_error_response(resource_status, url)
+        resource_status = client.request(url, method=requests.get,
+                                         message_prefix='Update status {}'.format(self.resource))
         resource_status_dict = parse_json(resource_status)
         resource_status_dict['event_type'] = 'update'
         resource_status_dict['event_name'] = 'update'
@@ -94,12 +94,10 @@ class ApiResource:
         Raises:
             PrevisionException: Any error while deleting data from the platform
         """
-        resp = client.request('/{}/{}'.format(self.resource, self._id), method=requests.delete)
-        if resp.status_code in [200, 204]:
-            logger.info('[Delete {} OK]'.format(self.resource))
-            return
-        else:
-            raise PrevisionException('[Delete {}] Error'.format(self.resource))
+        _ = client.request('/{}/{}'.format(self.resource, self._id),
+                           method=requests.delete,
+                           message_prefix='Delete {}'.format(self.resource))
+        logger.info('[Delete {} OK]'.format(self.resource))
 
     @classmethod
     def _from_id(cls, _id: str = None, specific_url: str = None) -> Dict:
@@ -125,9 +123,9 @@ class ApiResource:
             url = '/{}/{}'.format(cls.resource, _id)
         else:
             url = specific_url
-        resp = client.request(url, method=requests.get)
+        resp = client.request(url, method=requests.get,
+                              message_prefix='From id {}'.format(cls.resource))
 
-        handle_error_response(resp, url)
         resp_json = parse_json(resp)
         if _id is not None:
             logger.info('[Fetch {} OK] by id: "{}"'.format(cls.__name__, _id))
@@ -155,7 +153,8 @@ class ApiResource:
         if all:
             return get_all_results(client, url, method=requests.get)
         else:
-            resources = client.request(url, method=requests.get)
+            resources = client.request(url, method=requests.get,
+                                       message_prefix='List {}'.format(cls.resource))
             return parse_json(resources)['items']
 
     # def edit(self, **kwargs):
@@ -189,8 +188,6 @@ class ApiResource:
     #     resp = client.request(url,
     #                           body=update_fields,
     #                           method=requests.put)
-
-    #     handle_error_response(resp, url)
 
     #     resp_json = parse_json(resp)
 

--- a/previsionio/connector.py
+++ b/previsionio/connector.py
@@ -84,6 +84,7 @@ class Connector(ApiResource, UniqueResourceMixin):
             'port': port,
             'type': conn_type
         }
+        message_prefix = 'New connector creation'
         if username:
             data['username'] = username
         if password:
@@ -91,10 +92,11 @@ class Connector(ApiResource, UniqueResourceMixin):
         if googleCredentials:
             data['googleCredentials'] = googleCredentials
             content_type = 'application/json'
-            resp = client.request('/projects/{}/{}'.format(project_id, cls.resource), data=data,
-                                  method=requests.post, content_type=content_type)
+            resp = client.request('/projects/{}/{}'.format(project_id, cls.resource), data=data, method=requests.post,
+                                  content_type=content_type, message_prefix=message_prefix)
         else:
-            resp = client.request('/projects/{}/{}'.format(project_id, cls.resource), data=data, method=requests.post)
+            resp = client.request('/projects/{}/{}'.format(project_id, cls.resource), data=data, method=requests.post,
+                                  message_prefix=message_prefix)
 
         resp_json = parse_json(resp)
         if '_id' not in resp_json:
@@ -112,7 +114,7 @@ class Connector(ApiResource, UniqueResourceMixin):
         Returns:
             dict: Test results
         """
-        resp = client.request('/connectors/{}/test'.format(self.id), method=requests.post)
+        resp = client.request('/connectors/{}/test'.format(self.id), method=requests.post, check_response=False)
         if resp.status_code == 200:
             return True
         else:
@@ -130,8 +132,7 @@ class DataTableBaseConnector(Connector):
             dict: Databases information
         """
         url = '/{}/{}/databases'.format(self.resource, self._id)
-        resp = client.request(url, requests.get)
-        handle_error_response(resp, url)
+        resp = client.request(url, requests.get, message_prefix='Databases listing')
         resp_json = parse_json(resp)
         return resp_json['items']
 
@@ -145,8 +146,7 @@ class DataTableBaseConnector(Connector):
             dict: Tables information
         """
         url = '/{}/{}/databases/{}/tables'.format(self.resource, self._id, database)
-        resp = client.request(url, requests.get)
-        handle_error_response(resp, url)
+        resp = client.request(url, requests.get, message_prefix='Tables listing')
         resp_json = parse_json(resp)
         return resp_json['items']
 
@@ -164,7 +164,7 @@ class DataFileBaseConnector(Connector):
             dict: files information
         """
         url = '/{}/{}/paths'.format(self.resource, self._id)
-        resp = client.request(url, requests.get)
+        resp = client.request(url, requests.get, message_prefix='Datasource files listing')
         handle_error_response(resp, url)
         resp_json = parse_json(resp)
         return resp_json['items']

--- a/previsionio/connector.py
+++ b/previsionio/connector.py
@@ -1,7 +1,7 @@
 from typing import Union
 import requests
 from . import client
-from .utils import parse_json, handle_error_response
+from .utils import parse_json
 from .api_resource import ApiResource, UniqueResourceMixin
 
 
@@ -165,7 +165,6 @@ class DataFileBaseConnector(Connector):
         """
         url = '/{}/{}/paths'.format(self.resource, self._id)
         resp = client.request(url, requests.get, message_prefix='Datasource files listing')
-        handle_error_response(resp, url)
         resp_json = parse_json(resp)
         return resp_json['items']
 

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -292,7 +292,7 @@ class Dataset(ApiResource):
             # If not a zip, assert it is a CSV
             else:
                 with open(file_name, 'r') as f:
-                    files['file'] = (os.path.basename(file_name), f, 'application/csv')
+                    files['file'] = (os.path.basename(file_name), f, 'text/csv')
 
                     for k, v in data.items():
                         files[k] = (None, v)

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import os
 import tempfile
-from zipfile import ZipFile
+import zipfile
 import previsionio.utils
 from . import client
 from .utils import parse_json, zip_to_pandas, PrevisionException
@@ -259,7 +259,7 @@ class Dataset(ApiResource):
                 dataframe.to_csv(temp.name, index=False)
 
                 file_name = temp.name.replace('.csv', file_ext)
-                with ZipFile(file_name, 'w') as zip_file:
+                with zipfile.ZipFile(file_name, 'w') as zip_file:
                     zip_file.write(temp.name, arcname=name + '.csv')
                 assert zip_file.filename is not None
 
@@ -276,7 +276,7 @@ class Dataset(ApiResource):
 
         elif file_name is not None:
 
-            if zip_file.is_zipfile(file_name):
+            if zipfile.is_zipfile(file_name):
                 with open(file_name, 'rb') as f:
                     files['file'] = (os.path.basename(file_name), f, 'application/zip')
 
@@ -317,6 +317,10 @@ class Dataset(ApiResource):
 
         dset_resp = client.request(url, method=requests.get, message_prefix='Dataset loading')
         dset_json = parse_json(dset_resp)
+
+        if dataframe is not None:
+            os.remove(file_name)
+
         return cls(**dset_json)
 
 

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -264,7 +264,7 @@ class Dataset(ApiResource):
 
                 file_name = temp.name.replace('.csv', file_ext)
                 with ZipFile(file_name, 'w') as zip_file:
-                    zip_file.write(temp.name, arcname=name + '.csv')
+                    zip_file.write(temp.name, arcname=name + file_ext)
                 assert zip_file.filename is not None
                 with open(zip_file.filename, 'rb') as f:
                     files['file'] = (os.path.basename(file_name), f)

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -275,17 +275,34 @@ class Dataset(ApiResource):
                                                  message_prefix='Dataset upload from dataframe')
 
         elif file_name is not None:
-            with open(file_name, 'r') as f:
-                files['file'] = (os.path.basename(file_name), f, 'application/csv')
 
-                for k, v in data.items():
-                    files[k] = (None, v)
+            if zip_file.is_zipfile(file_name):
+                with open(file_name, 'rb') as f:
+                    files['file'] = (os.path.basename(file_name), f, 'application/zip')
 
-                create_resp = client.request(request_url,
-                                             data=data,
-                                             files=files,
-                                             method=requests.post,
-                                             message_prefix='Dataset upload from file')
+                    for k, v in data.items():
+                        files[k] = (None, v)
+
+                    create_resp = client.request(request_url,
+                                                 data=data,
+                                                 files=files,
+                                                 method=requests.post,
+                                                 message_prefix='Dataset upload from zip file')
+
+            # If not a zip, assert it is a CSV
+            else:
+                with open(file_name, 'r') as f:
+                    files['file'] = (os.path.basename(file_name), f, 'application/csv')
+
+                    for k, v in data.items():
+                        files[k] = (None, v)
+
+                    create_resp = client.request(request_url,
+                                                 data=data,
+                                                 files=files,
+                                                 method=requests.post,
+                                                 message_prefix='Dataset upload from csv file')
+
         if create_resp is None:
             raise PrevisionException('[Dataset] Unexpected case in dataset creation')
 

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -264,11 +264,11 @@ class Dataset(ApiResource):
 
                 file_name = temp.name.replace('.csv', file_ext)
                 with ZipFile(file_name, 'w') as zip_file:
-                    zip_file.write(temp.name, arcname=name + file_ext)
+                    zip_file.write(temp.name, arcname=name + '.csv')
                 assert zip_file.filename is not None
-                with open(zip_file.filename, 'rb') as f:
-                    files['file'] = (os.path.basename(file_name), f)
 
+                with open(zip_file.filename, 'rb') as f:
+                    files['file'] = (os.path.basename(file_name), f, 'application/zip')
                     for k, v in data.items():
                         files[k] = (None, v)
 

--- a/previsionio/dataset.py
+++ b/previsionio/dataset.py
@@ -10,7 +10,7 @@ import tempfile
 from zipfile import ZipFile
 import previsionio.utils
 from . import client
-from .utils import handle_error_response, parse_json, zip_to_pandas, PrevisionException
+from .utils import parse_json, zip_to_pandas, PrevisionException
 from .api_resource import ApiResource
 from . import logger
 import previsionio as pio
@@ -62,16 +62,12 @@ class Dataset(ApiResource):
         if self._data is not None:
             return self._data
         else:
-            response = client.request(endpoint='/{}/{}/download'
-                                      .format(self.resource, self.id),
-                                      method=requests.get)
+            response = client.request(endpoint='/{}/{}/download'.format(self.resource, self.id),
+                                      method=requests.get,
+                                      message_prefix='Dataset download')
 
-            if response.ok:
-                pd_df = zip_to_pandas(response, separator=self.separator)
-                self._data = pd_df
-            else:
-                msg = 'Failed to download dataset {}: {}'.format(self.id, response.text)
-                raise PrevisionException(msg)
+            self._data = zip_to_pandas(response, separator=self.separator)
+
             return self._data
 
     data = property(to_pandas)
@@ -103,7 +99,7 @@ class Dataset(ApiResource):
 
     def update_status(self):
         url = '/{}/{}'.format(self.resource, self._id)
-        dset_resp = client.request(url, method=requests.get)
+        dset_resp = client.request(url, method=requests.get, message_prefix='Dataset status update')
         dset_json = parse_json(dset_resp)
         self.describe_state = dset_json['describe_state']
         self.drift_state = dset_json['drift_state']
@@ -125,9 +121,9 @@ class Dataset(ApiResource):
             PrevisionException: If the dataset does not exist
             requests.exceptions.ConnectionError: Error processing the request
         """
-        resp = client.request(endpoint='/{}/{}'
-                              .format(self.resource, self.id),
-                              method=requests.delete)
+        resp = client.request(endpoint='/{}/{}'.format(self.resource, self.id),
+                              method=requests.delete,
+                              message_prefix='Dataset delete')
         return resp
 
     def start_embedding(self):
@@ -138,9 +134,9 @@ class Dataset(ApiResource):
             requests.exceptions.ConnectionError: request error
         """
 
-        resp = client.request(endpoint='/{}/{}/analysis'
-                              .format(self.resource, self.id),
-                              method=requests.post)
+        resp = client.request(endpoint='/{}/{}/analysis'.format(self.resource, self.id),
+                              method=requests.post,
+                              message_prefix='Dataset start embedding')
 
         logger.info('Started embedding for dataset {}'.format(self.name))
         resp = parse_json(resp)
@@ -153,21 +149,17 @@ class Dataset(ApiResource):
             PrevisionException: DatasetNotFoundError
             requests.exceptions.ConnectionError: request error
         """
-        endpoint = '/{}/{}/explorer'.format(self.resource, self.id)
-        resp = client.request(endpoint=endpoint, method=requests.get)
-        if resp.status_code == 404 or resp.status_code == 501 or resp.status_code == 502:
-            logger.warning('Dataset {} has not been analyzed yet. '
-                           'Cannot retrieve embedding.'.format(self.name))
-        else:
-            handle_error_response(resp, endpoint)
+        resp = client.request(endpoint='/{}/{}/explorer'.format(self.resource, self.id),
+                              method=requests.get,
+                              message_prefix='Dataset get embedding')
 
         tensors_shape = parse_json(resp)['embeddings'][0]['tensorShape']
-        labels_resp = client.request(endpoint='/{}/{}/explorer/labels.bytes'
-                                     .format(self.resource, self.id),
-                                     method=requests.get)
-        tensors_resp = client.request(endpoint='/{}/{}/explorer/tensors.bytes'
-                                      .format(self.resource, self.id),
-                                      method=requests.get)
+        labels_resp = client.request(endpoint='/{}/{}/explorer/labels.bytes'.format(self.resource, self.id),
+                                     method=requests.get,
+                                     message_prefix='Dataset labels bytes')
+        tensors_resp = client.request(endpoint='/{}/{}/explorer/tensors.bytes'.format(self.resource, self.id),
+                                      method=requests.get,
+                                      message_prefix='Dataset tensors bytes')
 
         labels = pd.read_csv(StringIO(labels_resp.text), sep="\t")
         tensors = np.frombuffer(BytesIO(tensors_resp.content).read(),
@@ -191,16 +183,19 @@ class Dataset(ApiResource):
         """
         endpoint = '/{}/{}/download'.format(self.resource, self.id)
         resp = client.request(endpoint=endpoint,
-                              method=requests.get)
-        handle_error_response(resp, endpoint)
+                              method=requests.get,
+                              message_prefix='Dataset download')
+
         if resp._content is None:
             raise PrevisionException('could not download dataset')
 
         if not download_path:
             download_path = os.getcwd()
         path = os.path.join(download_path, self.name + ".zip")
+
         with open(path, "wb") as file:
             file.write(resp._content)
+
         return path
 
     @classmethod
@@ -254,7 +249,8 @@ class Dataset(ApiResource):
             data['datasource_id'] = datasource.id
             create_resp = client.request(request_url,
                                          data=data,
-                                         method=requests.post)
+                                         method=requests.post,
+                                         message_prefix='Dataset upload from datasource')
 
         elif dataframe is not None:
             file_ext = '.zip'
@@ -275,11 +271,12 @@ class Dataset(ApiResource):
                     create_resp = client.request(request_url,
                                                  data=data,
                                                  files=files,
-                                                 method=requests.post)
+                                                 method=requests.post,
+                                                 message_prefix='Dataset upload from dataframe')
 
         elif file_name is not None:
             with open(file_name, 'r') as f:
-                files['file'] = (os.path.basename(file_name), f)
+                files['file'] = (os.path.basename(file_name), f, 'application/csv')
 
                 for k, v in data.items():
                     files[k] = (None, v)
@@ -287,11 +284,11 @@ class Dataset(ApiResource):
                 create_resp = client.request(request_url,
                                              data=data,
                                              files=files,
-                                             method=requests.post)
+                                             method=requests.post,
+                                             message_prefix='Dataset upload from file')
         if create_resp is None:
-            raise PrevisionException('[Dataset] Uexpected case in dataset creation')
+            raise PrevisionException('[Dataset] Unexpected case in dataset creation')
 
-        handle_error_response(create_resp, request_url, data)
         create_json = parse_json(create_resp)
         url = '/{}/{}'.format(cls.resource, create_json['_id'])
         event_tuple = previsionio.utils.EventTuple('DATASET_UPDATE', 'describe_state', 'done',
@@ -301,7 +298,7 @@ class Dataset(ApiResource):
                                                 event_tuple,
                                                 specific_url=url)
 
-        dset_resp = client.request(url, method=requests.get)
+        dset_resp = client.request(url, method=requests.get, message_prefix='Dataset loading')
         dset_json = parse_json(dset_resp)
         return cls(**dset_json)
 
@@ -339,9 +336,9 @@ class DatasetImages(ApiResource):
             PrevisionException: If the dataset images does not exist
             requests.exceptions.ConnectionError: Error processing the request
         """
-        resp = client.request(endpoint='/{}/{}'
-                              .format(self.resource, self.id),
-                              method=requests.delete)
+        resp = client.request(endpoint='/{}/{}'.format(self.resource, self.id),
+                              method=requests.delete,
+                              message_prefix='Image folder delete')
         return resp
 
     @classmethod
@@ -395,10 +392,9 @@ class DatasetImages(ApiResource):
 
         create_resp = client.request(request_url,
                                      files=files,
-                                     method=requests.post)
+                                     method=requests.post,
+                                     message_prefix='Image folder upload')
         source.close()
-
-        handle_error_response(create_resp, request_url)
 
         create_json = parse_json(create_resp)
         url = '/{}/{}'.format(cls.resource, create_json['_id'])
@@ -408,7 +404,7 @@ class DatasetImages(ApiResource):
                                                     'FOLDER_UPDATE', 'state', 'done', [('state', 'failed')]),
                                                 specific_url=url)
 
-        dset_resp = client.request(url, method=requests.get)
+        dset_resp = client.request(url, method=requests.get, message_prefix='Image folder loading')
         dset_json = parse_json(dset_resp)
         return cls(**dset_json)
 
@@ -429,8 +425,8 @@ class DatasetImages(ApiResource):
         """
         endpoint = '/{}/{}/download'.format(self.resource, self.id)
         resp = client.request(endpoint=endpoint,
-                              method=requests.get)
-        handle_error_response(resp, endpoint)
+                              method=requests.get,
+                              message_prefix='Image folder download')
         if resp._content is None:
             raise PrevisionException('could not download dataset')
         if not download_path:

--- a/previsionio/datasource.py
+++ b/previsionio/datasource.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import requests
 
 from . import client
-from .utils import handle_error_response, parse_json, PrevisionException
+from .utils import parse_json, PrevisionException
 from .api_resource import ApiResource, UniqueResourceMixin
 
 
@@ -90,8 +90,7 @@ class DataSource(ApiResource, UniqueResourceMixin):
         """
         # FIXME GET datasource should not return a dict with a "data" key
         url = '/{}/{}'.format(cls.resource, _id)
-        resp = client.request(url, method=requests.get)
-        handle_error_response(resp, url)
+        resp = client.request(url, method=requests.get, message_prefix='From id data source')
         resp_json = parse_json(resp)
 
         return cls(**resp_json)
@@ -135,8 +134,8 @@ class DataSource(ApiResource, UniqueResourceMixin):
         url = '/projects/{}/{}'.format(project_id, cls.resource)
         resp = client.request(url,
                               data=data,
-                              method=requests.post)
-        handle_error_response(resp, url, data)
+                              method=requests.post,
+                              message_prefix='Datasource creation')
         json = parse_json(resp)
 
         if '_id' not in json:

--- a/previsionio/deployed_model.py
+++ b/previsionio/deployed_model.py
@@ -88,14 +88,14 @@ class DeployedModel(object):
             elif self.token_creation_date and self.refresh_expires_in:
                 if time() < self.token_creation_date + self.refresh_expires_in:
                     # refresh token
-                    _ = self._refresh_token()
+                    self._refresh_token()
                 else:
                     # generate token
-                    _ = self._generate_token()
+                    self._generate_token()
             else:
-                _ = self._generate_token()
+                self._generate_token()
         else:
-            _ = self._generate_token()
+            self._generate_token()
 
     def check_types(self, features):
         for feature, value in features:

--- a/previsionio/plotter.py
+++ b/previsionio/plotter.py
@@ -302,8 +302,8 @@ class MatplotlibPlotter(Plotter):
 
         """
         if self.usecase.training_type != TypeProblem.MultiClassification:
-            raise Exception('Confusion matrices only available for multiclassification, not ' +
-                            self.usecase.training_type)
+            raise Exception(('Confusion matrices only available for multiclassification, not '
+                             self.usecase.training_type))
 
         # retrieve current list of predictions if necessary
         if len(self.usecase.predictions) == 0:
@@ -367,8 +367,8 @@ class MatplotlibPlotter(Plotter):
 
         """
         if self.usecase.training_type != TypeProblem.Classification:
-            raise Exception('Classification analysis plots only available for classification, not ' +
-                            self.usecase.training_type)
+            raise Exception(('Classification analysis plots only available for classification, not '
+                             self.usecase.training_type))
 
         # retrieve current list of predictions if necessary
         if len(self.usecase.predictions) == 0:

--- a/previsionio/plotter.py
+++ b/previsionio/plotter.py
@@ -302,8 +302,8 @@ class MatplotlibPlotter(Plotter):
 
         """
         if self.usecase.training_type != TypeProblem.MultiClassification:
-            raise Exception(('Confusion matrices only available for multiclassification, not '
-                             self.usecase.training_type))
+            raise Exception('Confusion matrices only available for multiclassification, not {}'.format(
+                            self.usecase.training_type))
 
         # retrieve current list of predictions if necessary
         if len(self.usecase.predictions) == 0:
@@ -367,8 +367,8 @@ class MatplotlibPlotter(Plotter):
 
         """
         if self.usecase.training_type != TypeProblem.Classification:
-            raise Exception(('Classification analysis plots only available for classification, not '
-                             self.usecase.training_type))
+            raise Exception('Classification analysis plots only available for classification, not {}'.format(
+                            self.usecase.training_type))
 
         # retrieve current list of predictions if necessary
         if len(self.usecase.predictions) == 0:

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -80,7 +80,7 @@ class EventManager:
 
     def check_resource_event(self, resource_id: str, endpoint: str, event_tuple: previsionio.utils.EventTuple,
                              semd: threading.Semaphore):
-        resp = self.client.request(endpoint=endpoint, method=requests.get)
+        resp = self.client.request(endpoint=endpoint, method=requests.get, check_response=False)
         if resp.status_code != 200:
             semd.release()
             msg = 'Error on resource {}: {}\n{}'.format(resource_id, resp.status_code, resp.text)

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -260,7 +260,7 @@ class Client(object):
                 status_code = resp.status_code
 
             except Exception as e:
-                logger.warning('failed to request ' + url + ' retrying ' + str(retries - n_tries) + ' times: ' + e.__repr__())
+                logger.warning(f'failed to request {url} retrying {retries - n_tries} times: {e.__repr__()}')
                 if n_tries == retries:
                     raise PrevisionException('error requesting: {} after {} retries'.format(url, n_tries))
                 continue

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -260,9 +260,9 @@ class Client(object):
                 status_code = resp.status_code
 
             except Exception as e:
-                logger.warning(f'failed to request {url} retrying {retries - n_tries} times: {e.__repr__()}')
+                logger.warning(f'Failed to request {url} retrying {retries - n_tries} times: {e.__repr__()}')
                 if n_tries == retries:
-                    raise PrevisionException('error requesting: {} after {} retries'.format(url, n_tries))
+                    raise PrevisionException(f'Error requesting: {url} after {n_tries} retries')
                 continue
 
             if status_code in config.retry_codes:

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -268,7 +268,12 @@ class Client(object):
                 time.sleep(config.request_retry_time)
 
         if check_response:
-            handle_error_response(resp, url, data, message_prefix=message_prefix, n_tries=n_tries)
+            handle_error_response(resp=resp,
+                                  url=url,
+                                  data=data,
+                                  files=files,
+                                  message_prefix=message_prefix,
+                                  n_tries=n_tries)
 
         return resp
 

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -216,7 +216,7 @@ class Client(object):
             raise PrevisionException('No url configured. Call client.init_client() to initialize')
 
     def request(self, endpoint: str, method, files: Dict = None, data: Dict = None, allow_redirects: bool = True,
-                content_type: str = None, no_retries: bool = False, check_response: int = True,
+                content_type: str = None, no_retries: bool = False, check_response: bool = True,
                 message_prefix: str = None, **requests_kwargs) -> Response:
         """
         Make a request on the desired endpoint with the specified method & data.

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -249,6 +249,7 @@ class Client(object):
 
         while (n_tries < retries) and (status_code in config.retry_codes):
             n_tries += 1
+
             try:
                 resp: Response = method(url,
                                         headers=headers,
@@ -256,13 +257,14 @@ class Client(object):
                                         allow_redirects=allow_redirects,
                                         json=data,
                                         **requests_kwargs)
+                status_code = resp.status_code
+
             except Exception as e:
                 logger.warning('failed to request ' + url + ' retrying ' + str(retries - n_tries) + ' times: ' + e.__repr__())
                 if n_tries == retries:
                     raise PrevisionException('error requesting: {} after {} retries'.format(url, n_tries))
                 continue
 
-            status_code = resp.status_code
             if status_code in config.retry_codes:
                 time.sleep(config.request_retry_time)
 

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -216,7 +216,8 @@ class Client(object):
             raise PrevisionException('No url configured. Call client.init_client() to initialize')
 
     def request(self, endpoint: str, method, files: Dict = None, data: Dict = None, allow_redirects: bool = True,
-                content_type: str = None, no_retries: bool = False, **requests_kwargs) -> Response:
+                content_type: str = None, no_retries: bool = False, check_response: int = True,
+                message_prefix: str = None, **requests_kwargs) -> Response:
         """
         Make a request on the desired endpoint with the specified method & data.
 
@@ -230,6 +231,8 @@ class Client(object):
             content_type (str): force request content-type
             allow_redirects (bool): passed to requests method
             no_retries (bool): force request to run the first time, or exit directly
+            check_response (bool): wether to handle error or not
+            message_prefix (str): prefix message in error logs
 
         Returns:
             request response
@@ -264,8 +267,8 @@ class Client(object):
             if not no_retries and status_code in config.retry_codes:
                 time.sleep(config.request_retry_time)
 
-        if status_code != 200:
-            raise ValueError(f'failed to request "{url}", status_code "{status_code}" after {n_tries} tries.')
+        if check_response:
+            handle_error_response(resp, url, data, message_prefix=message_prefix, n_tries=n_tries)
 
         return resp
 

--- a/previsionio/prevision_client.py
+++ b/previsionio/prevision_client.py
@@ -251,21 +251,21 @@ class Client(object):
 
         while (n_tries < retries) and (status_code in config.retry_codes):
 
-            try:
-                resp: Response = method(url,
-                                        headers=headers,
-                                        files=files,
-                                        allow_redirects=allow_redirects,
-                                        json=data,
-                                        **requests_kwargs)
-                n_tries += 1
-                status_code = resp.status_code
+            resp: Response = method(url,
+                                    headers=headers,
+                                    files=files,
+                                    allow_redirects=allow_redirects,
+                                    json=data,
+                                    **requests_kwargs)
 
-                if not no_retries and status_code in config.retry_codes:
-                    time.sleep(config.request_retry_time)
+            n_tries += 1
+            status_code = resp.status_code
 
-            except Exception as e:
-                logger.warning('failed to request ' + url + ': ' + e.__repr__())
+            if not no_retries and status_code in config.retry_codes:
+                time.sleep(config.request_retry_time)
+
+        if status_code != 200:
+            raise ValueError(f'failed to request "{url}", status_code "{status_code}" after {n_tries} tries.')
 
         return resp
 

--- a/previsionio/project.py
+++ b/previsionio/project.py
@@ -9,7 +9,7 @@ from previsionio.usecase_config import ColumnConfig, DataType, TrainingConfig, T
 import requests
 
 from . import client
-from .utils import handle_error_response, parse_json, PrevisionException
+from .utils import parse_json, PrevisionException
 
 from .api_resource import ApiResource, UniqueResourceMixin
 from .datasource import DataSource
@@ -110,8 +110,9 @@ class Project(ApiResource, UniqueResourceMixin):
         """
         # FIXME GET datasource should not return a dict with a "data" key
         url = '/{}/{}'.format(cls.resource, _id)
-        resp = client.request(url, method=requests.get)
-        handle_error_response(resp, url)
+        resp = client.request(url,
+                              method=requests.get,
+                              message_prefix='Projects list')
         resp_json = parse_json(resp)
 
         return cls(**resp_json)
@@ -135,9 +136,9 @@ class Project(ApiResource, UniqueResourceMixin):
         """
 
         end_point = '/{}/{}/users'.format(self.resource, self._id)
-        response = client.request(endpoint=end_point, method=requests.get)
-        handle_error_response(response, end_point,
-                              message_prefix="Error while fetching user for project id {}".format(self._id))
+        response = client.request(endpoint=end_point,
+                                  method=requests.get,
+                                  message_prefix='Fetching user for project id {}'.format(self._id))
 
         res = parse_json(response)
         return res
@@ -183,7 +184,7 @@ class Project(ApiResource, UniqueResourceMixin):
 
     @classmethod
     def new(cls, name: str, description: str = None, color: ProjectColor = None) -> 'Project':
-        """ Create a new datasource object on the platform.
+        """ Create a new project on the platform.
 
         Args:
             name (str): Name of the project
@@ -209,9 +210,9 @@ class Project(ApiResource, UniqueResourceMixin):
         url = '/{}'.format(cls.resource)
         resp = client.request(url,
                               data=data,
-                              method=requests.post)
+                              method=requests.post,
+                              message_prefix='Project creation')
 
-        handle_error_response(resp, url, data)
         json = parse_json(resp)
 
         if '_id' not in json:
@@ -230,9 +231,9 @@ class Project(ApiResource, UniqueResourceMixin):
             PrevisionException: If the dataset does not exist
             requests.exceptions.ConnectionError: Error processing the request
         """
-        resp = client.request(endpoint='/{}/{}'
-                              .format(self.resource, self.id),
-                              method=requests.delete)
+        resp = client.request(endpoint='/{}/{}'.format(self.resource, self.id),
+                              method=requests.delete,
+                              message_prefix='Project delete')
         return resp
 
     def create_dataset(self, name: str, datasource: DataSource = None, file_name: str = None,

--- a/previsionio/project.py
+++ b/previsionio/project.py
@@ -18,7 +18,8 @@ from .connector import Connector, SQLConnector, FTPConnector, \
     SFTPConnector, S3Connector, HiveConnector, GCPConnector
 from .supervised import Supervised
 from .timeseries import TimeSeries, TimeWindow
-from .text_similarity import DescriptionsColumnConfig, ListModelsParameters, QueriesColumnConfig, TextSimilarity, TextSimilarityLang
+from .text_similarity import (DescriptionsColumnConfig, ListModelsParameters, QueriesColumnConfig,
+                              TextSimilarity, TextSimilarityLang)
 from .usecase import Usecase
 from pandas import DataFrame
 

--- a/previsionio/supervised.py
+++ b/previsionio/supervised.py
@@ -8,8 +8,7 @@ from previsionio.dataset import Dataset, DatasetImages
 from . import TrainingConfig
 from . import metrics
 from .usecase_version import ClassicUsecaseVersion
-from .model import Model, RegressionModel, \
-    ClassificationModel, MultiClassificationModel
+from .model import RegressionModel, ClassificationModel, MultiClassificationModel
 from .utils import EventTuple, handle_error_response, parse_json, to_json
 from .prevision_client import client
 import previsionio as pio

--- a/previsionio/supervised.py
+++ b/previsionio/supervised.py
@@ -9,7 +9,7 @@ from . import TrainingConfig
 from . import metrics
 from .usecase_version import ClassicUsecaseVersion
 from .model import RegressionModel, ClassificationModel, MultiClassificationModel
-from .utils import EventTuple, handle_error_response, parse_json, to_json
+from .utils import EventTuple, parse_json, to_json
 from .prevision_client import client
 import previsionio as pio
 
@@ -187,8 +187,11 @@ class Supervised(ClassicUsecaseVersion):
 
         params.update(fit_params)
         endpoint = "/usecases/{}/versions".format(self.usecase_id)
-        resp = client.request(endpoint=endpoint, data=params, method=requests.post, content_type='application/json')
-        handle_error_response(resp, endpoint, params)
+        resp = client.request(endpoint=endpoint,
+                              data=params,
+                              method=requests.post,
+                              content_type='application/json',
+                              message_prefix='Usecase creation')
         json = parse_json(resp)
 
         usecase = self.from_id(json["_id"])

--- a/previsionio/text_similarity.py
+++ b/previsionio/text_similarity.py
@@ -43,7 +43,10 @@ class TextSimilarityLang(Enum):
 class Preprocessing(object):
     config = {}
 
-    def __init__(self, word_stemming: YesOrNo = YesOrNo.Yes, ignore_stop_word: YesOrNoOrAuto = YesOrNoOrAuto.Auto, ignore_punctuation: YesOrNo = YesOrNo.Yes):
+    def __init__(self,
+                 word_stemming: YesOrNo = YesOrNo.Yes,
+                 ignore_stop_word: YesOrNoOrAuto = YesOrNoOrAuto.Auto,
+                 ignore_punctuation: YesOrNo = YesOrNo.Yes):
         self.word_stemming = word_stemming
         self.ignore_stop_word = ignore_stop_word
         self.ignore_punctuation = ignore_punctuation
@@ -217,10 +220,20 @@ class TextSimilarity(BaseUsecaseVersion):
         return cls(**super()._load(pio_file))
 
     @classmethod
-    def _fit(cls, project_id: str, name: str, dataset: Dataset, description_column_config: DescriptionsColumnConfig,
-             metric: pio.metrics.TextSimilarity = pio.metrics.TextSimilarity.accuracy_at_k, top_k: int = 10,
-             lang: TextSimilarityLang = TextSimilarityLang.Auto, queries_dataset: Dataset = None, queries_column_config: QueriesColumnConfig = None,
-             models_parameters: ListModelsParameters = ListModelsParameters(), **kwargs) -> 'TextSimilarity':
+    def _fit(
+        cls,
+        project_id: str,
+        name: str,
+        dataset: Dataset,
+        description_column_config: DescriptionsColumnConfig,
+        metric: pio.metrics.TextSimilarity = pio.metrics.TextSimilarity.accuracy_at_k,
+        top_k: int = 10,
+        lang: TextSimilarityLang = TextSimilarityLang.Auto,
+        queries_dataset: Dataset = None,
+        queries_column_config: QueriesColumnConfig = None,
+        models_parameters: ListModelsParameters = ListModelsParameters(),
+        **kwargs
+    ) -> 'TextSimilarity':
         """ Start a supervised usecase training with a specific training configuration
         (on the platform).
 

--- a/previsionio/text_similarity.py
+++ b/previsionio/text_similarity.py
@@ -4,7 +4,7 @@ from previsionio.dataset import Dataset
 import requests
 from .usecase_config import DataType, UsecaseConfig, TypeProblem, YesOrNo, YesOrNoOrAuto
 from .prevision_client import client
-from .utils import handle_error_response, parse_json, EventTuple, to_json
+from .utils import parse_json, EventTuple, to_json
 from .model import TextSimilarityModel
 from .usecase_version import BaseUsecaseVersion
 import previsionio as pio
@@ -279,9 +279,11 @@ class TextSimilarity(BaseUsecaseVersion):
         data = dict(name=name, dataset_id=dataset_id, **training_args)
 
         endpoint = '/projects/{}/{}/{}/{}'.format(project_id, 'usecases', cls.data_type.value, cls.training_type.value)
-        start = client.request(endpoint, requests.post, data=data, content_type='application/json')
-
-        handle_error_response(start, endpoint, data, "text_similality usecase failed to start")
+        start = client.request(endpoint,
+                               method=requests.post,
+                               data=data,
+                               content_type='application/json',
+                               message_prefix='Text similarity usecase start')
 
         start_response = parse_json(start)
         usecase = cls.from_id(start_response['_id'])
@@ -371,9 +373,11 @@ class TextSimilarity(BaseUsecaseVersion):
             data["description"] = description
 
         endpoint = "/usecases/{}/versions".format(self.usecase_id)
-        resp = client.request(endpoint=endpoint, data=data, method=requests.post, content_type='application/json')
-
-        handle_error_response(resp, endpoint, data, "text_similality usecase failed to start")
+        resp = client.request(endpoint=endpoint,
+                              data=data,
+                              method=requests.post,
+                              content_type='application/json',
+                              message_prefix='Text similarity usecase start')
 
         start_response = parse_json(resp)
         usecase = self.from_id(start_response['_id'])

--- a/previsionio/timeseries.py
+++ b/previsionio/timeseries.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from typing import Dict
 
 import requests
-from previsionio.utils import EventTuple, handle_error_response, parse_json, to_json
+from previsionio.utils import EventTuple, parse_json, to_json
 from . import TrainingConfig
 from .usecase_config import DataType, UsecaseConfig, ColumnConfig, TypeProblem
 from .usecase_version import ClassicUsecaseVersion
@@ -199,8 +199,11 @@ class TimeSeries(ClassicUsecaseVersion):
 
         endpoint = "/usecases/{}/versions".format(self.usecase_id)
 
-        resp = client.request(endpoint=endpoint, data=params, method=requests.post, content_type='application/json')
-        handle_error_response(resp, endpoint, params)
+        resp = client.request(endpoint=endpoint,
+                              data=params,
+                              method=requests.post,
+                              content_type='application/json',
+                              message_prefix='Time series usecase start')
         json = parse_json(resp)
 
         usecase = self.from_id(json["_id"])

--- a/previsionio/usecase.py
+++ b/previsionio/usecase.py
@@ -74,7 +74,9 @@ class Usecase(ApiResource):
             list(dict): List of the usecase versions (as JSON metadata)
         """
         end_point = '/{}/{}/versions'.format(self.resource, self._id)
-        response = client.request(endpoint=end_point, method=requests.get)
+        response = client.request(endpoint=end_point,
+                                  method=requests.get,
+                                  message_prefix='Usecase versions listing')
         res = parse_json(response)
         # TODO create usecase version object
         return res['items']
@@ -86,5 +88,6 @@ class Usecase(ApiResource):
             dict: Deletion process results
         """
         response = client.request(endpoint='/usecases/{}'.format(self._id),
-                                  method=requests.delete)
+                                  method=requests.delete,
+                                  message_prefix='Usecase deletion')
         return response

--- a/previsionio/usecase_config.py
+++ b/previsionio/usecase_config.py
@@ -219,8 +219,8 @@ class TrainingConfig(UsecaseConfig):
             at the end of the training by cherry-picking already trained models and fine-tuning
             hyperparameters (usually gives even better performance)
         feature_time_seconds (int, optional): feature selection take at most fsel_time in seconds
-        feature_number_kept (int, optional): a feature selection algorithm is launched to keep at most `feature_number_kept` features
-
+        feature_number_kept (int, optional): a feature selection algorithm is launched to keep at most
+            `feature_number_kept` features
     """
 
     config = {
@@ -250,7 +250,8 @@ class TrainingConfig(UsecaseConfig):
             features (Feature, optional): Names of the feature engineering modules to use
             with_blend (bool, optional): models selectioned are also launched as blend
             feature_time_seconds (int, optional): feature selection take at most fsel_time in seconds
-            feature_number_kept (int, optional): a feature selection algorithm is launched to keep at most `feature_number_kept` features
+            feature_number_kept (int, optional): a feature selection algorithm is launched to keep at most
+                `feature_number_kept` features
         """
 
         self.features = features

--- a/previsionio/usecase_config.py
+++ b/previsionio/usecase_config.py
@@ -1,8 +1,6 @@
 import copy
 from enum import Enum
-from sys import api_version
-from typing import Dict, List, Union
-from .utils import to_json
+from typing import List, Union
 
 
 def _drop_in_list(feature_list: List, param_to_drop: List):

--- a/previsionio/usecase_version.py
+++ b/previsionio/usecase_version.py
@@ -11,7 +11,8 @@ import os
 from functools import lru_cache
 
 from . import config
-from .usecase_config import AdvancedModel, DataType, Feature, NormalModel, Profile, SimpleModel, TrainingConfig, ColumnConfig, TypeProblem, UsecaseState
+from .usecase_config import (AdvancedModel, DataType, Feature, NormalModel, Profile, SimpleModel,
+                             TrainingConfig, ColumnConfig, TypeProblem, UsecaseState)
 from .logger import logger
 from .prevision_client import client
 from .utils import handle_error_response, parse_json, EventTuple, PrevisionException, zip_to_pandas, get_all_results
@@ -556,7 +557,8 @@ class ClassicUsecaseVersion(BaseUsecaseVersion):
         Returns:
             list(str): Names of the feature engineering modules selected for the usecase
         """
-        return [Feature(f) for f in self._status['usecase_version_params'].get('features_engineering_selected_list', [])]
+        res = [Feature(f) for f in self._status['usecase_version_params'].get('features_engineering_selected_list', [])]
+        return res
 
     def get_cv(self) -> pd.DataFrame:
         """ Get the cross validation dataset from the best model of the usecase.

--- a/previsionio/utils.py
+++ b/previsionio/utils.py
@@ -123,7 +123,9 @@ def get_all_results(client, endpoint: str, method) -> List[Dict]:
 
 def handle_error_response(
     resp: Response,
-    url: str, data: Union[Dict, List] = None,
+    url: str,
+    data: Union[Dict, List] = None,
+    files: Dict = None,
     message_prefix: str = None,
     n_tries: int = 1,
     additional_log: str = None,
@@ -135,6 +137,8 @@ def handle_error_response(
             message += " after {} tries".format(n_tries)
         if data:
             message += " with data: {}".format(data)
+        if files:
+            message += " with files: {}".format(files)
         if message_prefix:
             message = message_prefix + ' failure\n' + message
         logger.error(message)

--- a/previsionio/utils.py
+++ b/previsionio/utils.py
@@ -10,7 +10,7 @@ import os
 from collections import namedtuple
 import numpy as np
 from requests.models import Response
-from . import logger
+from . import logger, config
 import datetime
 from math import ceil
 
@@ -127,11 +127,14 @@ def handle_error_response(
     resp: Response,
     url: str, data: Union[Dict, List] = None,
     message_prefix: str = None,
+    n_tries: int = 1,
     additional_log: str = None,
 ):
-    if resp.status_code != 200:
+    if resp.status_code not in config.success_codes:
         message = "Error {}: '{}' reaching url: '{}'".format(
             resp.status_code, resp.text, url)
+        if n_tries > 1:
+            message += " after {} tries".format(n_tries)
         if data:
             message += " with data: {}".format(data)
         if message_prefix:

--- a/previsionio/utils.py
+++ b/previsionio/utils.py
@@ -138,7 +138,7 @@ def handle_error_response(
         if data:
             message += " with data: {}".format(data)
         if message_prefix:
-            message = message_prefix + '\n' + message
+            message = message_prefix + ' failure\n' + message
         logger.error(message)
         if additional_log:
             logger.error(additional_log)

--- a/previsionio/utils.py
+++ b/previsionio/utils.py
@@ -109,7 +109,6 @@ def is_null_value(value) -> bool:
 def get_all_results(client, endpoint: str, method) -> List[Dict]:
     resources = []
     batch: requests.Response = client.request(endpoint, method=method)
-    handle_error_response(batch, endpoint)
     json = parse_json(batch)
     meta = json['metaData']
     total_items = meta['totalItems']
@@ -118,7 +117,6 @@ def get_all_results(client, endpoint: str, method) -> List[Dict]:
     for n in range(1, n_pages + 1):
         url = endpoint + "?page={}".format(n)
         batch = client.request(url, method=method)
-        handle_error_response(batch, url)
         resources.extend(parse_json(batch)['items'])
     return resources
 

--- a/utests/datasets.py
+++ b/utests/datasets.py
@@ -5,6 +5,7 @@ import glob
 import numpy as np
 import pandas as pd
 import requests
+import zipfile
 
 URLS = {
     "titanic": [
@@ -105,6 +106,18 @@ def make_supervised_datasets(path,
     ts_path = os.path.join(path, 'ts.csv')
     ts.to_csv(ts_path, index=False)
 
+    # zip
+    X_reg = np.random.rand(n_smp, n_feat_reg)
+    y_reg = np.random.rand(n_smp)
+    reg = pd.DataFrame(X_reg,
+                       columns=['feat_{}'.format(i) for i in range(n_feat_reg)])
+    reg['target'] = y_reg
+    reg_path2 = os.path.join(path, 'zip_regression.csv')
+    reg.to_csv(reg_path2, index=False)
+    zip_path = reg_path2.replace('.csv', '.zip')
+    with zipfile.ZipFile(zip_path, 'w') as zip_file:
+        zip_file.write(reg_path2)
+
     # big
     # n_smp_big = 10000
     # n_feat_big = 100
@@ -119,6 +132,7 @@ def make_supervised_datasets(path,
         'regression': reg_path,
         'classification': classif_path,
         'multiclassification': mclassif_path,
+        'zip_regression': zip_path,
         # 'timeseries': ts_path,
         # 'big': big_path
     }
@@ -127,6 +141,8 @@ def make_supervised_datasets(path,
 def remove_datasets(path):
     if os.path.exists(path):
         for f in glob.glob(os.path.join(path, '*.csv')):
+            os.remove(f)
+        for f in glob.glob(os.path.join(path, '*.zip')):
             os.remove(f)
         os.rmdir(path)
 

--- a/utests/test_dataset.py
+++ b/utests/test_dataset.py
@@ -69,7 +69,8 @@ def test_embedding():
     ds = pio.Dataset.from_id(ds._id)
     ds.start_embedding()
     t0 = time.time()
-    while ds.get_embedding_status() in [UsecaseState.Pending, UsecaseState.Running] and time.time() < t0 + pio.config.default_timeout:
+    states = [UsecaseState.Pending, UsecaseState.Running]
+    while ds.get_embedding_status() in states and time.time() < t0 + pio.config.default_timeout:
         ds.update_status()
 
     embedding = ds.get_embedding()

--- a/utests/test_image_embeddings.py
+++ b/utests/test_image_embeddings.py
@@ -56,8 +56,8 @@ def test_run_image_embeddings():
     uc_name = TESTING_ID + '_img_embeds'
     datasets = (test_datasets['csv'], test_datasets['zip'])
     project = pio.Project.from_id(PROJECT_ID)
-    usecase_version = project.fit_image_multiclassification(uc_name, dataset=datasets, column_config=col_config,
-                                                            metric=pio.metrics.MultiClassification.error_rate,
-                                                            training_config=uc_config)
+    usecase_version = project.fit_image_classification(uc_name, dataset=datasets, column_config=col_config,
+                                                       metric=pio.metrics.Classification.AUC,
+                                                       training_config=uc_config)
     usecase_version.wait_until(lambda usecasev: len(usecasev.models) > 0)
     usecase_version.usecase.delete()

--- a/utests/test_supervised.py
+++ b/utests/test_supervised.py
@@ -112,7 +112,8 @@ def setup_usecase_class(request):
         lambda usecase: (len(usecase.models) > 0) or (usecase._status['state'] == 'failed'))
     assert uc.running
     uc.stop()
-    uc.wait_until(lambda usecase: usecase._status['state'] == 'done')
+    uc.wait_until(lambda usecase: usecase._status['state'] == 'done', timeout=60)
+    assert uc._status['state'] == 'done'
     yield request.param, uc
     _ = uc.usecase.delete()
 

--- a/utests/test_supervised.py
+++ b/utests/test_supervised.py
@@ -1,7 +1,6 @@
 import os
 from previsionio.usecase_version import ClassicUsecaseVersion
 from typing import Tuple
-from previsionio.usecase import Usecase
 from previsionio.model import ClassificationModel
 import pandas as pd
 import pytest

--- a/utests/test_supervised.py
+++ b/utests/test_supervised.py
@@ -95,7 +95,8 @@ def test_usecase_version():
 def test_stop_running_usecase():
     uc_name = TESTING_ID + '_file_run'
     usecase_version = supervised_from_filename('regression', uc_name)
-    usecase_version.wait_until(lambda usecase: len(usecase.models) > 0)
+    usecase_version.wait_until(
+        lambda usecase: (len(usecase.models) > 0) or (usecase._status['state'] == 'failed'))
     assert usecase_version.running
     usecase_version.stop()
     usecase_version.update_status()
@@ -107,7 +108,9 @@ def test_stop_running_usecase():
 def setup_usecase_class(request):
     usecase_name = '{}_{}'.format(request.param[0:5], TESTING_ID)
     uc = supervised_from_filename(request.param, usecase_name)
-    uc.wait_until(lambda usecase: len(usecase.models) > 0)
+    uc.wait_until(
+        lambda usecase: (len(usecase.models) > 0) or (usecase._status['state'] == 'failed'))
+    assert uc.running
     uc.stop()
     uc.wait_until(lambda usecase: usecase._status['state'] == 'done')
     yield request.param, uc

--- a/utests/test_text_similarity.py
+++ b/utests/test_text_similarity.py
@@ -135,10 +135,12 @@ class BaseTrainSearchDelete(unittest.TestCase):
                            'models': [TextSimilarityModels.BruteForce, TextSimilarityModels.ClusterPruning]},
                           {'model_embedding': ModelEmbedding.Transformer,
                            'preprocessing': {},
-                           'models': [TextSimilarityModels.BruteForce, TextSimilarityModels.LSH, TextSimilarityModels.HKM]},
+                           'models': [TextSimilarityModels.BruteForce, TextSimilarityModels.LSH,
+                                      TextSimilarityModels.HKM]},
                           {'model_embedding': ModelEmbedding.TransformerFineTuned,
                            'preprocessing': {},
-                           'models': [TextSimilarityModels.BruteForce, TextSimilarityModels.LSH, TextSimilarityModels.HKM]}]
+                           'models': [TextSimilarityModels.BruteForce, TextSimilarityModels.LSH,
+                                      TextSimilarityModels.HKM]}]
         models_parameters = pio.ListModelsParameters(usecase_config)
         uc = pio.TextSimilarity._fit(PROJECT_ID,
                                      'test_sdk_3_text_similarity_{}'.format(TESTING_ID),

--- a/utests/test_text_similarity.py
+++ b/utests/test_text_similarity.py
@@ -9,7 +9,7 @@ from .utils import get_testing_id
 
 TESTING_ID = get_testing_id()
 
-PROJECT_NAME = "sdk_test_usecase_" + str(TESTING_ID)
+PROJECT_NAME = "sdk_test_text_sim_usecase_" + str(TESTING_ID)
 PROJECT_ID = ""
 
 test_datasets = {}

--- a/utests/utils.py
+++ b/utests/utils.py
@@ -8,12 +8,12 @@ DROP_COLS = ['feat_0']
 def train_model(project_id, uc_name, dataset, training_type, training_type_func, training_config):
     project = pio.Project.from_id(project_id)
     training_type_func = getattr(project, training_type_func)
-    return training_type_func(uc_name,
-                             dataset,
-                             pio.ColumnConfig(target_column='target',
-                                              drop_list=DROP_COLS
-                                              ),
-                             training_config=training_config)
+    return training_type_func(
+        uc_name,
+        dataset,
+        pio.ColumnConfig(target_column='target', drop_list=DROP_COLS),
+        training_config=training_config,
+    )
 
 
 def get_testing_id():


### PR DESCRIPTION
1. client.request():
    - Fix retry policy: only retry if status code in [500, 502, 503, 504]
    - Always handle error after request
    - Clean client.request() usage
2. dataset_upload:
    - Add content type
    - Remove temp zip if from_dataframe
    - Check if zip or csv if from_filename
    - Add utests for from_filename